### PR TITLE
Define global variable for all prefixes

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use sqlx::{sqlite::SqlitePool, Row, SqlitePool as Pool};
 
+use crate::utils::constants::BLACKLISTED_PREFIXES;
+
 pub struct Database {
     pool: Pool,
 }
@@ -113,18 +115,10 @@ impl Database {
         .execute(&self.pool)
         .await?;
 
-        let prefix_list = [
-            "$", "&", "!", ".", "m.", ">", "<", "[", "]", "@", "#", "%", "^", "*", ",",
-        ];
-
         let mut local_counts: HashMap<String, i32> = HashMap::new();
 
         for word in content.split_whitespace() {
             let word_lower = word.to_lowercase();
-
-            if prefix_list.iter().any(|&p| p == word_lower) {
-                continue;
-            }
             *local_counts.entry(word_lower).or_insert(0) += 1;
         }
 
@@ -287,11 +281,7 @@ impl Database {
         guild_id: u64,
         min_letters_amount: u64,
     ) -> Result<Option<(String, u64)>, sqlx::Error> {
-        let prefix_list: Vec<&str> = vec![
-            "$", "&", "!", ".", "m.", ">", "<", "[", "]", "@", "#", "^", "*", ",", "https", "http",
-        ];
-
-        let prefix_conditions = prefix_list
+        let prefix_conditions = BLACKLISTED_PREFIXES
             .iter()
             .map(|_| "content NOT LIKE ? || '%'")
             .collect::<Vec<_>>()
@@ -326,7 +316,7 @@ impl Database {
             .bind(min_id)
             .bind(min_letters_amount as i64);
 
-        for prefix in &prefix_list {
+        for prefix in &BLACKLISTED_PREFIXES {
             query_builder = query_builder.bind(*prefix);
         }
 

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -1,0 +1,3 @@
+pub const BLACKLISTED_PREFIXES: [&str; 16] = [
+    "$", "&", "!", ".", "m.", ">", "<", "[", "]", "@", "#", "^", "*", ",", "https", "http",
+];

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use serenity::all::{ChannelId, Context, GuildId};
 
 use crate::database::Database;
+use crate::utils::constants::BLACKLISTED_PREFIXES;
 use crate::utils::markov_chain;
 use crate::MarkovChainGlobal;
 
@@ -30,15 +31,11 @@ pub async fn generate_markov_message(
         }
     }
 
-    let prefixes = [
-        "$", "&", "!", ".", "m.", ">", "<", "[", "]", "@", "#", "^", "*", ",", "https", "http",
-    ];
-
     let sentences = match database
         .get_messages_for_markov(
             guild_id.get(),
             channel_id.get(),
-            &prefixes,
+            &BLACKLISTED_PREFIXES,
             DATABASE_MESSAGE_FETCH_LIMIT,
         )
         .await

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod constants;
 pub mod helpers;
 pub mod markov_chain;
 pub mod string_cmp;


### PR DESCRIPTION
Previously every file used its own array of blacklisted prefixes.
This PR combines all of the arrays into a single global array so the files can access the same array.